### PR TITLE
Add the correct dates to schedules table

### DIFF
--- a/build/report.junit.xml
+++ b/build/report.junit.xml
@@ -1,61 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="TeamManager Test Suite" tests="20" assertions="26" errors="2" warnings="0" failures="0" skipped="0" time="0.226258">
-    <testsuite name="Marcusmyers\TeamManager\Tests\Feature\AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/AthleteTest.php" tests="1" assertions="2" errors="0" warnings="0" failures="0" skipped="0" time="0.079819">
-      <testcase name="the_route_can_be_accessed" class="Marcusmyers\TeamManager\Tests\Feature\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Feature.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/AthleteTest.php" line="11" assertions="2" time="0.079819"/>
+  <testsuite name="TeamManager Test Suite" tests="20" assertions="28" errors="0" warnings="0" failures="0" skipped="0" time="0.398216">
+    <testsuite name="Marcusmyers\TeamManager\Tests\Feature\AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/AthleteTest.php" tests="1" assertions="2" errors="0" warnings="0" failures="0" skipped="0" time="0.212177">
+      <testcase name="the_route_can_be_accessed" class="Marcusmyers\TeamManager\Tests\Feature\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Feature.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/AthleteTest.php" line="11" assertions="2" time="0.212177"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Feature\CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/CoachTest.php" tests="1" assertions="2" errors="0" warnings="0" failures="0" skipped="0" time="0.006119">
-      <testcase name="the_route_can_be_accessed" class="Marcusmyers\TeamManager\Tests\Feature\CoachTest" classname="Marcusmyers.TeamManager.Tests.Feature.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/CoachTest.php" line="11" assertions="2" time="0.006119"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Feature\CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/CoachTest.php" tests="1" assertions="2" errors="0" warnings="0" failures="0" skipped="0" time="0.007237">
+      <testcase name="the_route_can_be_accessed" class="Marcusmyers\TeamManager\Tests\Feature\CoachTest" classname="Marcusmyers.TeamManager.Tests.Feature.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/CoachTest.php" line="11" assertions="2" time="0.007237"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Feature\TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/TeamTest.php" tests="1" assertions="3" errors="0" warnings="0" failures="0" skipped="0" time="0.016218">
-      <testcase name="the_route_can_be_accessed" class="Marcusmyers\TeamManager\Tests\Feature\TeamTest" classname="Marcusmyers.TeamManager.Tests.Feature.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/TeamTest.php" line="13" assertions="3" time="0.016218"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Feature\TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/TeamTest.php" tests="1" assertions="3" errors="0" warnings="0" failures="0" skipped="0" time="0.038133">
+      <testcase name="the_route_can_be_accessed" class="Marcusmyers\TeamManager\Tests\Feature\TeamTest" classname="Marcusmyers.TeamManager.Tests.Feature.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Feature/TeamTest.php" line="13" assertions="3" time="0.038133"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" tests="6" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="0.037472">
-      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="25" assertions="1" time="0.006518"/>
-      <testcase name="it_can_properly_set_the_email_address" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="33" assertions="1" time="0.005556"/>
-      <testcase name="it_can_properly_set_the_birthday" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="44" assertions="2" time="0.008749"/>
-      <testcase name="it_can_properly_parse_the_athletes_name" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="56" assertions="2" time="0.005405"/>
-      <testcase name="it_can_get_active_athletes" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="65" assertions="1" time="0.005259"/>
-      <testcase name="the_athlete_can_be_added_to_a_team" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="73" assertions="1" time="0.005985"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" tests="6" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="0.041072">
+      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="25" assertions="1" time="0.008609"/>
+      <testcase name="it_can_properly_set_the_email_address" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="33" assertions="1" time="0.007380"/>
+      <testcase name="it_can_properly_set_the_birthday" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="44" assertions="2" time="0.006708"/>
+      <testcase name="it_can_properly_parse_the_athletes_name" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="56" assertions="2" time="0.005543"/>
+      <testcase name="it_can_get_active_athletes" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="65" assertions="1" time="0.006080"/>
+      <testcase name="the_athlete_can_be_added_to_a_team" class="Marcusmyers\TeamManager\Tests\Unit\AthleteTest" classname="Marcusmyers.TeamManager.Tests.Unit.AthleteTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/AthleteTest.php" line="73" assertions="1" time="0.006752"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" tests="4" assertions="4" errors="1" warnings="0" failures="0" skipped="0" time="0.024089">
-      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="14" assertions="1" time="0.005786"/>
-      <testcase name="it_can_get_active_coaches" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="24" assertions="0" time="0.005791">
-        <error type="BadMethodCallException">Marcusmyers\TeamManager\Tests\Unit\CoachTest::it_can_get_active_coaches
-BadMethodCallException: Call to undefined method Marcusmyers\TeamManager\Models\Coach::active()
-
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:50
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:36
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1618
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1630
-/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php:28
-</error>
-      </testcase>
-      <testcase name="it_can_properly_parse_the_coaches_name" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="34" assertions="2" time="0.006175"/>
-      <testcase name="it_can_be_added_to_a_team" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="44" assertions="1" time="0.006337"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" tests="4" assertions="5" errors="0" warnings="0" failures="0" skipped="0" time="0.023741">
+      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="14" assertions="1" time="0.006460"/>
+      <testcase name="it_can_get_active_coaches" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="24" assertions="1" time="0.005824"/>
+      <testcase name="it_can_properly_parse_the_coaches_name" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="34" assertions="2" time="0.005246"/>
+      <testcase name="it_can_be_added_to_a_team" class="Marcusmyers\TeamManager\Tests\Unit\CoachTest" classname="Marcusmyers.TeamManager.Tests.Unit.CoachTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/CoachTest.php" line="44" assertions="1" time="0.006210"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\ScheduleTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTest.php" tests="2" assertions="3" errors="0" warnings="0" failures="0" skipped="0" time="0.012764">
-      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\ScheduleTest" classname="Marcusmyers.TeamManager.Tests.Unit.ScheduleTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTest.php" line="14" assertions="2" time="0.006491"/>
-      <testcase name="it_can_properly_parse_the_team_name" class="Marcusmyers\TeamManager\Tests\Unit\ScheduleTest" classname="Marcusmyers.TeamManager.Tests.Unit.ScheduleTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTest.php" line="27" assertions="1" time="0.006273"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\ScheduleTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTest.php" tests="2" assertions="3" errors="0" warnings="0" failures="0" skipped="0" time="0.025260">
+      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\ScheduleTest" classname="Marcusmyers.TeamManager.Tests.Unit.ScheduleTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTest.php" line="14" assertions="2" time="0.019169"/>
+      <testcase name="it_can_properly_parse_the_team_name" class="Marcusmyers\TeamManager\Tests\Unit\ScheduleTest" classname="Marcusmyers.TeamManager.Tests.Unit.ScheduleTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTest.php" line="27" assertions="1" time="0.006091"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\ScheduleTypeTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTypeTest.php" tests="1" assertions="1" errors="0" warnings="0" failures="0" skipped="0" time="0.007948">
-      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\ScheduleTypeTest" classname="Marcusmyers.TeamManager.Tests.Unit.ScheduleTypeTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTypeTest.php" line="14" assertions="1" time="0.007948"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\ScheduleTypeTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTypeTest.php" tests="1" assertions="1" errors="0" warnings="0" failures="0" skipped="0" time="0.007638">
+      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\ScheduleTypeTest" classname="Marcusmyers.TeamManager.Tests.Unit.ScheduleTypeTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/ScheduleTypeTest.php" line="14" assertions="1" time="0.007638"/>
     </testsuite>
-    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" tests="4" assertions="3" errors="1" warnings="0" failures="0" skipped="0" time="0.041829">
-      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="26" assertions="1" time="0.005722"/>
-      <testcase name="it_can_get_active_teams" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="34" assertions="0" time="0.005984">
-        <error type="BadMethodCallException">Marcusmyers\TeamManager\Tests\Unit\TeamTest::it_can_get_active_teams
-BadMethodCallException: Call to undefined method Marcusmyers\TeamManager\Models\Team::active()
-
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:50
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:36
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1618
-/Users/mmyers/Documents/Code/team-manager/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1630
-/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php:36
-</error>
-      </testcase>
-      <testcase name="it_can_have_multiple_coaches" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="42" assertions="1" time="0.006778"/>
-      <testcase name="it_can_have_big_team_of_athletes" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="57" assertions="1" time="0.023345"/>
+    <testsuite name="Marcusmyers\TeamManager\Tests\Unit\TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" tests="4" assertions="4" errors="0" warnings="0" failures="0" skipped="0" time="0.042958">
+      <testcase name="it_can_access_the_database" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="26" assertions="1" time="0.006240"/>
+      <testcase name="it_can_get_active_teams" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="34" assertions="1" time="0.005259"/>
+      <testcase name="it_can_have_multiple_coaches" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="42" assertions="1" time="0.008005"/>
+      <testcase name="it_can_have_big_team_of_athletes" class="Marcusmyers\TeamManager\Tests\Unit\TeamTest" classname="Marcusmyers.TeamManager.Tests.Unit.TeamTest" file="/Users/mmyers/Documents/Code/team-manager/tests/Unit/TeamTest.php" line="57" assertions="1" time="0.023454"/>
     </testsuite>
   </testsuite>
 </testsuites>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Laravel package to manage a Team of Athletes",
     "type": "library",
     "license": "MIT",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "authors": [
         {
             "name": "Mark Myers",

--- a/database/migrations/add_end_time_to_schedules_table.php.stub
+++ b/database/migrations/add_end_time_to_schedules_table.php.stub
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEndTimeToSchedules extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->dateTime('end_time')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->dropColumn('end_time');
+        });
+    }
+}

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -10,6 +10,7 @@ class Schedule extends Model
 {
 	protected $guarded = [];
 	protected $table = 'schedules';
+    protected $dates = ['schedule_date_time','end_time'];
 
 	public function team()
 	{
@@ -18,6 +19,6 @@ class Schedule extends Model
 
 	public function schedule_types()
 	{
-		return $this->belongsTo('Marcusmyers\TeamManager\Models\ScheduleType');
+		return $this->belongsTo('Marcusmyers\TeamManager\Models\ScheduleType', 'schedule_type_id');
 	}
 }

--- a/src/TeamManagerServiceProvider.php
+++ b/src/TeamManagerServiceProvider.php
@@ -31,7 +31,7 @@ class TeamManagerServiceProvider extends ServiceProvider
 				__DIR__ . '/../database/factories/TeamFactory.php' => database_path('factories/TeamFactory.php')
 			], 'factories');
 		}
-		
+
 		if (! class_exists('CreateAthletesTable')) {
 			$this->publishes([
 				__DIR__ . '/../database/migrations/create_athletes_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_athletes_table.php')
@@ -68,6 +68,12 @@ class TeamManagerServiceProvider extends ServiceProvider
 			], 'migrations');
 		}
 
+        if (class_exists('CreateSchedulesTable') && !class_exists('AddEndTimeToSchedules')) {
+            $this->publishes([
+              __DIR__ . '/../database/migrations/add_end_time_to_schedules_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_add_end_time_to_schedules_table.php')
+            ], 'migrations');
+        }
+
 		if (! class_exists('CreateScheduleTypesTable')) {
 			$this->publishes([
 				__DIR__ . '/../database/migrations/create_schedule_types_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_schedule_types_table.php')
@@ -83,6 +89,6 @@ class TeamManagerServiceProvider extends ServiceProvider
 
 	public function register()
 	{
-		
-	}	
+
+	}
 }


### PR DESCRIPTION
In order to properly get the correct schedule types this commit properly
used the foreign_key id in the model.  This commit also adds the dates
property to the schedule model.